### PR TITLE
make Enable SSO instruction more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ hackety tool to view github PRs for a period
 
 1. Create a gh token on [the settings tab](//github.com/settings/tokens/new)
     - use `repo` scope if you need private repos, otherwise `public_repo`
-    - if your org is protected by SSO, make sure to enable that for the token
+    - if your org is protected by SSO, make sure to enable that for the token by clicking the Authorize button within the Enable SSO dropdown
 1. Write out the settings file needed for this script
 
     ```bash


### PR DESCRIPTION
the Github UI is not the clearest, the dropdown menu is not showing you the status of SSO, but rather you need to click it in order to enable SSO

Github should probably make this a plain button instead, rather than a dropdown

![personal access tokens-1](https://user-images.githubusercontent.com/1182738/51137941-b6551880-17f4-11e9-9b8e-b5ae45c33019.jpg)