### PR TITLE
Catch HTTPError and pretty print the body.

### DIFF
--- a/gh_perf_review.py
+++ b/gh_perf_review.py
@@ -4,6 +4,7 @@ import datetime
 import json
 import sys
 import time
+import urllib.error
 import urllib.parse
 import urllib.request
 from typing import Any
@@ -87,7 +88,13 @@ def _parse_link(lnk: Optional[str]) -> Dict[str, str]:
 
 
 def _req(url: str, **kwargs: Any) -> Response:
-    resp = urllib.request.urlopen(urllib.request.Request(url, **kwargs))
+    try:
+        resp = urllib.request.urlopen(urllib.request.Request(url, **kwargs))
+    except urllib.error.HTTPError as e:
+        print(f'HTTPError {e.code} {e.reason}.')
+        print(json.dumps(json.loads(e.read().decode()), indent=4))
+        sys.exit(-1)
+
     # TODO: https://github.com/python/typeshed/issues/2333
     from typing import cast
     resp = cast(urllib.response.addinfourl, resp)


### PR DESCRIPTION
Github returns nice error messages from its API, but you have to read the body of the exception. This adds that so we get nicer messages when something goes wrong.

As an example, if you typed in an incorrect user:

```
$ python3 gh_perf_review.py lkasjdf 2018 h2
.HTTPError 422 Unprocessable Entity.
{
    "message": "Validation Failed",
    "errors": [
        {
            "message": "The listed users and repositories cannot be searched either because the resources do not exist or you do not have permission to view them.",
            "resource": "Search",
            "field": "q",
            "code": "invalid"
        }
    ],
    "documentation_url": "https://developer.github.com/v3/search/"
}