### PR TITLE
Add optional involves filter for filtering for PRs with a specific collaborator

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,14 @@ hackety tool to view github PRs for a period
 
 ## generating markdown output
 
-Usage: `python3 gh_perf_review.py ORG YEAR PERIOD [--user USER]`
+Usage: `python3 gh_perf_review.py ORG YEAR PERIOD [--user USER] [--involves INVOLVES]`
 
 - `ORG`: the github organization to search in
 - `YEAR`: the four digit year to search in
 - `PERIOD`: the time period to search in, currently supported: Q1, Q2, Q3, Q4,
   H1, H2, Y
 - `--user USER`: optional, will use the authenticated user otherwise
+- `--involves INVOLVES`: optional, will filter for reviews involving this reviewer
 
 The script writes its output to stdout, if you'd like to capture that, redirect
 it to a file:

--- a/gh_perf_review.py
+++ b/gh_perf_review.py
@@ -144,6 +144,7 @@ def main() -> int:
     parser.add_argument('year', type=int)
     parser.add_argument('period', type=str.lower, choices=PERIODS)
     parser.add_argument('--user')
+    parser.add_argument('--involves', type=str.lower)
     args = parser.parse_args()
 
     token = json.loads(open('.github-auth.json').read())['token']
@@ -160,6 +161,9 @@ def main() -> int:
         f'org:{args.org} is:pr is:merged author:{user} '
         f'merged:{args.year}-{start}..{args.year}-{end}'
     )
+    if args.involves:
+        query = f'{query} involves:{args.involves}'
+
     query = urllib.parse.quote(query)
     url = f'/search/issues?q={query}&per_page=100&sort=merged'
     resp = _get_all(url, headers=headers)


### PR DESCRIPTION
Usage: `python3 gh_perf_review.py lyft 2019 H2 --user babldev --involves shivtools`

Uses `involves` to filter who was involved in the review,