### PR TITLE
Add support for a 'custom period'

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,16 @@ hackety tool to view github PRs for a period
 
 ## generating markdown output
 
-Usage: `python3 gh_perf_review.py ORG YEAR PERIOD [--user USER] [--involves INVOLVES]`
+Usage: `python3 gh_perf_review.py ORG YEAR PERIOD [--api-root API_ROOT] [--user USER] [--involves INVOLVES] [--custom-period CUSTOM_PERIOD]`
 
 - `ORG`: the github organization to search in
 - `YEAR`: the four digit year to search in
 - `PERIOD`: the time period to search in, currently supported: Q1, Q2, Q3, Q4,
-  H1, H2, Y
+  H1, H2, Y, custom
 - `--api-root API_ROOT`: optional, will use https://api.github.com by default
 - `--user USER`: optional, will use the authenticated user otherwise
 - `--involves INVOLVES`: optional, will filter for reviews involving this reviewer
+- `--custom-period CUSTOM_PERIOD`: optional, a custom period in the format MM-DD,MM-DD. used with period=custom
 
 The script writes its output to stdout, if you'd like to capture that, redirect
 it to a file:


### PR DESCRIPTION
I need to write a review for Jan - Apr. Example output (for just Jan 2025 for brevity):

```console
$ python3 gh_perf_review.py pre-commit 2025 custom --custom-period 01-01,01-31 --user asottile
.
# asottile's 2025 01-01,01-31 summary (pre-commit)

- **5** PRs
- **5** repos

## by repository

|repo                              |prs|
|----------------------------------|---|
|pre-commit/identify               |  1|
|pre-commit/pre-commit             |  1|
|pre-commit/pre-commit-hooks       |  1|
|pre-commit/pre-commit-mirror-maker|  1|
|pre-commit/sync-pre-commit-deps   |  1|


## by date

### january (5 prs)

|date      |link                         |title                     |
|----------|-----------------------------|--------------------------|
|2025-01-30|[identify#504]               |upgrade asottile/workflows|
|2025-01-30|[pre-commit-hooks#1131]      |upgrade asottile/workflows|
|2025-01-30|[pre-commit-mirror-maker#234]|upgrade asottile/workflows|
|2025-01-30|[sync-pre-commit-deps#56]    |upgrade asottile/workflows|
|2025-01-30|[pre-commit#3396]            |upgrade asottile/workflows|



[identify#504]: https://github.com/pre-commit/identify/pull/504
[pre-commit-hooks#1131]: https://github.com/pre-commit/pre-commit-hooks/pull/1131
[pre-commit-mirror-maker#234]: https://github.com/pre-commit/pre-commit-mirror-maker/pull/234
[sync-pre-commit-deps#56]: https://github.com/pre-commit/sync-pre-commit-deps/pull/56
[pre-commit#3396]: https://github.com/pre-commit/pre-commit/pull/3396
```